### PR TITLE
explicitly check for module.exports; no globals if it does

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@
 	function CVSS3() { }
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = CVSS3;
 	}
 	global["CVSS3"] = CVSS3;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = CVSS3;
+		return;
 	}
 	global["CVSS3"] = CVSS3;
 

--- a/lib/base-a.js
+++ b/lib/base-a.js
@@ -82,6 +82,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseA;
+	    return;
 	}
 	global["CVSS3_Base_A"] = BaseA;
 

--- a/lib/base-a.js
+++ b/lib/base-a.js
@@ -80,7 +80,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseA;
 	}
 	global["CVSS3_Base_A"] = BaseA;

--- a/lib/base-ac.js
+++ b/lib/base-ac.js
@@ -78,7 +78,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseAC;
 	}
 	global["CVSS3_Base_AC"] = BaseAC;

--- a/lib/base-ac.js
+++ b/lib/base-ac.js
@@ -80,6 +80,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseAC;
+	    return;
 	}
 	global["CVSS3_Base_AC"] = BaseAC;
 

--- a/lib/base-av.js
+++ b/lib/base-av.js
@@ -82,7 +82,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseAV;
 	}
 	global["CVSS3_Base_AV"] = BaseAV;

--- a/lib/base-av.js
+++ b/lib/base-av.js
@@ -84,6 +84,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseAV;
+	    return;
 	}
 	global["CVSS3_Base_AV"] = BaseAV;
 

--- a/lib/base-c.js
+++ b/lib/base-c.js
@@ -80,7 +80,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseC;
 	}
 	global["CVSS3_Base_C"] = BaseC;

--- a/lib/base-c.js
+++ b/lib/base-c.js
@@ -82,6 +82,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseC;
+	    return;
 	}
 	global["CVSS3_Base_C"] = BaseC;
 

--- a/lib/base-i.js
+++ b/lib/base-i.js
@@ -82,6 +82,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseI;
+	    return;
 	}
 	global["CVSS3_Base_I"] = BaseI;
 

--- a/lib/base-i.js
+++ b/lib/base-i.js
@@ -80,7 +80,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseI;
 	}
 	global["CVSS3_Base_I"] = BaseI;

--- a/lib/base-pr.js
+++ b/lib/base-pr.js
@@ -100,7 +100,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BasePR;
 	}
 	global["CVSS3_Base_PR"] = BasePR;

--- a/lib/base-pr.js
+++ b/lib/base-pr.js
@@ -102,6 +102,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BasePR;
+	    return;
 	}
 	global["CVSS3_Base_PR"] = BasePR;
 

--- a/lib/base-s.js
+++ b/lib/base-s.js
@@ -91,6 +91,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseS;
+	    return;
 	}
 	global["CVSS3_Base_S"] = BaseS;
 

--- a/lib/base-s.js
+++ b/lib/base-s.js
@@ -89,7 +89,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseS;
 	}
 	global["CVSS3_Base_S"] = BaseS;

--- a/lib/base-ui.js
+++ b/lib/base-ui.js
@@ -78,7 +78,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseUI;
 	}
 	global["CVSS3_Base_UI"] = BaseUI;

--- a/lib/base-ui.js
+++ b/lib/base-ui.js
@@ -80,6 +80,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = BaseUI;
+	    return;
 	}
 	global["CVSS3_Base_UI"] = BaseUI;
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -280,6 +280,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = Base;
+	    return;
 	}
 	global["CVSS3_Base"] = Base;
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -46,7 +46,7 @@
 	function Base(av, ac, pr, ui, s, c, i, a) {
 
 		//initialize
-		if ("process" in global) {
+		if (typeof module === "object" && "exports" in module) {
 			this.av = new Base.AV();
 			this.ac = new Base.AC();
 			this.pr = new Base.PR();
@@ -278,7 +278,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = Base;
 	}
 	global["CVSS3_Base"] = Base;

--- a/lib/env-ar.js
+++ b/lib/env-ar.js
@@ -82,7 +82,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvAR;
 	}
 	global["CVSS3_Environmental_AR"] = EnvAR;

--- a/lib/env-ar.js
+++ b/lib/env-ar.js
@@ -84,6 +84,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvAR;
+	    return;
 	}
 	global["CVSS3_Environmental_AR"] = EnvAR;
 

--- a/lib/env-cr.js
+++ b/lib/env-cr.js
@@ -84,6 +84,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvCR;
+	    return;
 	}
 	global["CVSS3_Environmental_CR"] = EnvCR;
 

--- a/lib/env-cr.js
+++ b/lib/env-cr.js
@@ -82,7 +82,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvCR;
 	}
 	global["CVSS3_Environmental_CR"] = EnvCR;

--- a/lib/env-ir.js
+++ b/lib/env-ir.js
@@ -82,7 +82,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvIR;
 	}
 	global["CVSS3_Environmental_IR"] = EnvIR;

--- a/lib/env-ir.js
+++ b/lib/env-ir.js
@@ -84,6 +84,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvIR;
+	    return;
 	}
 	global["CVSS3_Environmental_IR"] = EnvIR;
 

--- a/lib/env-ma.js
+++ b/lib/env-ma.js
@@ -107,6 +107,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMA;
+	    return;
 	}
 	global["CVSS3_Environmental_MA"] = EnvMA;
 

--- a/lib/env-ma.js
+++ b/lib/env-ma.js
@@ -72,7 +72,7 @@
 			return 0.00;
 		} else { //Not Defined
 			if (isNull(base)) {
-				if ("process" in global) {
+				if (typeof module === "object" && "exports" in module) {
 					base = new BaseMetrics();
 				} else {
 					//for Browser (client side)
@@ -105,7 +105,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMA;
 	}
 	global["CVSS3_Environmental_MA"] = EnvMA;

--- a/lib/env-mac.js
+++ b/lib/env-mac.js
@@ -105,6 +105,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMAC;
+	    return;
 	}
 	global["CVSS3_Environmental_MAC"] = EnvMAC;
 

--- a/lib/env-mac.js
+++ b/lib/env-mac.js
@@ -70,7 +70,7 @@
 			return 0.44;
 		} else { //Not Defined
 			if (isNull(base)) {
-				if ("process" in global) {
+				if (typeof module === "object" && "exports" in module) {
 					base = new BaseMetrics();
 				} else {
 					//for Browser (client side)
@@ -103,7 +103,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMAC;
 	}
 	global["CVSS3_Environmental_MAC"] = EnvMAC;

--- a/lib/env-mav.js
+++ b/lib/env-mav.js
@@ -109,6 +109,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMAV;
+	    return;
 	}
 	global["CVSS3_Environmental_MAV"] = EnvMAV;
 

--- a/lib/env-mav.js
+++ b/lib/env-mav.js
@@ -74,7 +74,7 @@
 			return 0.20;
 		} else { //Not Defined
 			if (isNull(base)) {
-				if ("process" in global) {
+				if (typeof module === "object" && "exports" in module) {
 					base = new BaseMetrics();
 				} else {
 					//for Browser (client side)
@@ -107,7 +107,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMAV;
 	}
 	global["CVSS3_Environmental_MAV"] = EnvMAV;

--- a/lib/env-mc.js
+++ b/lib/env-mc.js
@@ -107,6 +107,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMC;
+	    return;
 	}
 	global["CVSS3_Environmental_MC"] = EnvMC;
 

--- a/lib/env-mc.js
+++ b/lib/env-mc.js
@@ -72,7 +72,7 @@
 			return 0.00;
 		} else { //Not Defined
 			if (isNull(base)) {
-				if ("process" in global) {
+				if (typeof module === "object" && "exports" in module) {
 					base = new BaseMetrics();
 				} else {
 					//for Browser (client side)
@@ -105,7 +105,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMC;
 	}
 	global["CVSS3_Environmental_MC"] = EnvMC;

--- a/lib/env-mi.js
+++ b/lib/env-mi.js
@@ -72,7 +72,7 @@
 			return 0.00;
 		} else { //Not Defined
 			if (isNull(base)) {
-				if ("process" in global) {
+				if (typeof module === "object" && "exports" in module) {
 					base = new BaseMetrics();
 				} else {
 					//for Browser (client side)
@@ -105,7 +105,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMI;
 	}
 	global["CVSS3_Environmental_MI"] = EnvMI;

--- a/lib/env-mi.js
+++ b/lib/env-mi.js
@@ -107,6 +107,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMI;
+    	return;
 	}
 	global["CVSS3_Environmental_MI"] = EnvMI;
 

--- a/lib/env-mpr.js
+++ b/lib/env-mpr.js
@@ -81,7 +81,7 @@
 			}
 		} else { //Not Define
 			if (isNull(base)) {
-				if ("process" in global) {
+				if (typeof module === "object" && "exports" in module) {
 					base = new BaseMetrics();
 				} else {
 					//for Browser (client side)
@@ -114,7 +114,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMPR;
 	}
 	global["CVSS3_Environmental_MPR"] = EnvMPR;

--- a/lib/env-mpr.js
+++ b/lib/env-mpr.js
@@ -116,6 +116,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMPR;
+    	return;
 	}
 	global["CVSS3_Environmental_MPR"] = EnvMPR;
 

--- a/lib/env-ms.js
+++ b/lib/env-ms.js
@@ -118,6 +118,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMS;
+    	return;
 	}
 	global["CVSS3_Environmental_MS"] = EnvMS;
 

--- a/lib/env-ms.js
+++ b/lib/env-ms.js
@@ -83,7 +83,7 @@
 			return false;
 		} else { //Not Defined
 			if (isNull(base)) {
-				if ("process" in global) {
+				if (typeof module === "object" && "exports" in module) {
 					base = new BaseMetrics();
 				} else {
 					//for Browser (client side)
@@ -116,7 +116,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMS;
 	}
 	global["CVSS3_Environmental_MS"] = EnvMS;

--- a/lib/env-mui.js
+++ b/lib/env-mui.js
@@ -105,6 +105,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMUI;
+    	return;
 	}
 	global["CVSS3_Environmental_MUI"] = EnvMUI;
 

--- a/lib/env-mui.js
+++ b/lib/env-mui.js
@@ -70,7 +70,7 @@
 			return 0.62;
 		} else { //Not Defined
 			if (isNull(base)) {
-				if ("process" in global) {
+				if (typeof module === "object" && "exports" in module) {
 					base = new BaseMetrics();
 				} else {
 					//for Browser (client side)
@@ -103,7 +103,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = EnvMUI;
 	}
 	global["CVSS3_Environmental_MUI"] = EnvMUI;

--- a/lib/env.js
+++ b/lib/env.js
@@ -359,6 +359,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = Env;
+    	return;
 	}
 	global["CVSS3_Environmental"] = Env;
 

--- a/lib/env.js
+++ b/lib/env.js
@@ -56,7 +56,7 @@
 	function Env(cr, ci, ca, mav, mac, ms, mpr, mui, mc, mi, ma) {
 
 		//initialize
-		if ("process" in global) {
+		if (typeof module === "object" && "exports" in module) {
 			this.cr = new Env.CR();
 			this.ir = new Env.IR();
 			this.ar = new Env.AR();
@@ -156,7 +156,7 @@
 	 */
 	function getScore(base, temporal) {
 		if (isNull(base)) {
-			if ("process" in global) {
+			if (typeof module === "object" && "exports" in module) {
 				base = new BaseMetrics();
 			} else {
 				//for Browser (client side)
@@ -164,7 +164,7 @@
 			}
 		}
 		if (isNull(temporal)) {
-			if ("process" in global) {
+			if (typeof module === "object" && "exports" in module) {
 				temporal = new TemporalMetrics();
 			} else {
 				//for Browser (client side)
@@ -305,7 +305,7 @@
 	function getVector(base, temporal) {
 		var vector = "";
 		if (isNull(base)) {
-			if ("process" in global) {
+			if (typeof module === "object" && "exports" in module) {
 				base = new BaseMetrics();
 			} else {
 				//for Browser (client side)
@@ -313,7 +313,7 @@
 			}
 		}
 		if (isNull(temporal)) {
-			if ("process" in global) {
+			if (typeof module === "object" && "exports" in module) {
 				temporal = new TemporalMetrics();
 			} else {
 				//for Browser (client side)
@@ -357,7 +357,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = Env;
 	}
 	global["CVSS3_Environmental"] = Env;

--- a/lib/tempo-e.js
+++ b/lib/tempo-e.js
@@ -84,7 +84,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = TempoE;
 	}
 	global["CVSS3_Temporal_E"] = TempoE;

--- a/lib/tempo-e.js
+++ b/lib/tempo-e.js
@@ -86,6 +86,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = TempoE;
+    	return;
 	}
 	global["CVSS3_Temporal_E"] = TempoE;
 

--- a/lib/tempo-rc.js
+++ b/lib/tempo-rc.js
@@ -82,7 +82,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = TempoRC;
 	}
 	global["CVSS3_Temporal_RC"] = TempoRC;

--- a/lib/tempo-rc.js
+++ b/lib/tempo-rc.js
@@ -84,6 +84,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = TempoRC;
+    	return;
 	}
 	global["CVSS3_Temporal_RC"] = TempoRC;
 

--- a/lib/tempo-rl.js
+++ b/lib/tempo-rl.js
@@ -86,6 +86,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = TempoRL;
+    	return;
 	}
 	global["CVSS3_Temporal_RL"] = TempoRL;
 

--- a/lib/tempo-rl.js
+++ b/lib/tempo-rl.js
@@ -84,7 +84,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = TempoRL;
 	}
 	global["CVSS3_Temporal_RL"] = TempoRL;

--- a/lib/temporal.js
+++ b/lib/temporal.js
@@ -36,7 +36,7 @@
 	function Temporal(e, rl, rc) {
 
 		//initialize
-		if ("process" in global) {
+		if (typeof module === "object" && "exports" in module) {
 			this.e = new Temporal.E();
 			this.rl = new Temporal.RL();
 			this.rc = new Temporal.RC();
@@ -96,7 +96,7 @@
 	 */
 	function getScore(base) {
 		if (isNull(base)) {
-			if ("process" in global) {
+			if (typeof module === "object" && "exports" in module) {
 				base = new BaseMetrics();
 			} else {
 				//for Browser (client side)
@@ -160,7 +160,7 @@
 	 */
 	function getVector(base) {
 		if (isNull(base)) {
-			if ("process" in global) {
+			if (typeof module === "object" && "exports" in module) {
 				base = new BaseMetrics();
 			} else {
 				//for Browser (client side)
@@ -196,7 +196,7 @@
 	}
 
 	// Exports
-	if ("process" in global) {
+	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = Temporal;
 	}
 	global["CVSS3_Temporal"] = Temporal;

--- a/lib/temporal.js
+++ b/lib/temporal.js
@@ -198,6 +198,7 @@
 	// Exports
 	if (typeof module === "object" && "exports" in module) {
 		module["exports"] = Temporal;
+    	return;
 	}
 	global["CVSS3_Temporal"] = Temporal;
 


### PR DESCRIPTION
1. explicitly check for module.exports
   - In the event that another JS lib defines a global named “process”, the `if (“process” in global)` test will result in error conditions.
2. if module.exports exists, don't set globals 
   - Globals are not allowed by default in some of the node.js community’s more popular testing libs. Also, if module.exports exists, it’s very unlikely that we’ll want the globals too. 
